### PR TITLE
Add the current request_id to the log when in Rails or Rory context.

### DIFF
--- a/lib/rf_logger/rails_logger.rb
+++ b/lib/rf_logger/rails_logger.rb
@@ -1,11 +1,11 @@
 require 'active_record'
-require "rf_logger/request_id"
+require "rf_logger/request_tags"
 
 module RfLogger
 
   class RailsLogger < ActiveRecord::Base
     self.table_name = "logs"
-    extend RequestId
+    extend RequestTags
     class << self
 
       RfLogger::LEVELS.each do |level|
@@ -16,7 +16,7 @@ module RfLogger
 
       def add(level, entry)
         create(
-          :request_id => request_id,
+          :rf_logger_request_tags => rf_logger_request_tags,
           :level => RfLogger::LEVELS.index(level.to_sym),
           :action => entry[:action],
           :actor => entry[:actor],

--- a/lib/rf_logger/rails_logger.rb
+++ b/lib/rf_logger/rails_logger.rb
@@ -1,10 +1,11 @@
 require 'active_record'
+require "rf_logger/request_id"
 
 module RfLogger
 
   class RailsLogger < ActiveRecord::Base
     self.table_name = "logs"
-
+    extend RequestId
     class << self
 
       RfLogger::LEVELS.each do |level|
@@ -15,6 +16,7 @@ module RfLogger
 
       def add(level, entry)
         create(
+          :request_id => request_id,
           :level => RfLogger::LEVELS.index(level.to_sym),
           :action => entry[:action],
           :actor => entry[:actor],

--- a/lib/rf_logger/request_id.rb
+++ b/lib/rf_logger/request_id.rb
@@ -1,0 +1,7 @@
+module RfLogger
+  module RequestId
+    def request_id
+      Thread.current[:rf_logger_request_id] || "uninitialized"
+    end
+  end
+end

--- a/lib/rf_logger/request_id.rb
+++ b/lib/rf_logger/request_id.rb
@@ -1,7 +1,0 @@
-module RfLogger
-  module RequestId
-    def request_id
-      Thread.current[:rf_logger_request_id] || "uninitialized"
-    end
-  end
-end

--- a/lib/rf_logger/request_middleware.rb
+++ b/lib/rf_logger/request_middleware.rb
@@ -1,12 +1,10 @@
 module RfLogger
   class RequestMiddleware
     # @param [Hash] options
-    # @option opts [Hash{:label => :request_method}] :tagged The subject
-    # @option opts [Class] :rack_request_class
+    # @option opts [Hash{:label => "header_name"}] :tagged The subject
     def initialize(app, options={})
       @app                = app
-      @tagged             = options.fetch(:tagged, { request_id: :uuid })
-      @rack_request_class = options.fetch(:rack_request_class){request_class}
+      @tagged             = options.fetch(:tagged, { request_id: "X-Request-Id" })
     end
 
     def call(env)
@@ -17,7 +15,7 @@ module RfLogger
 
     def tagged
       @tagged.each_with_object({}) do |(key, value), hash|
-        hash[key] = request_object.send(value) if request_object.respond_to? value
+        hash[key] = @env[value]
       end
     end
 
@@ -25,21 +23,6 @@ module RfLogger
 
     def set_tagged_thread_var
       (Thread.current[:inheritable_attributes] ||= {})[:rf_logger_request_tags] = tagged
-    end
-
-    def request_object
-      @request_object ||= @rack_request_class.new(@env)
-    end
-
-    def request_class
-      case
-      when defined? ActionDispatch::Request
-        ActionDispatch::Request
-      when defined? Rory::Request
-        Rory::Request
-      else
-        raise ArgumentError, "Unknown framework context - :rack_request_class key needed."
-      end
     end
   end
 end

--- a/lib/rf_logger/request_middleware.rb
+++ b/lib/rf_logger/request_middleware.rb
@@ -24,8 +24,7 @@ module RfLogger
     private
 
     def set_tagged_thread_var
-      Thread.current[:inheritable_attributes] = {} unless Thread.current[:inheritable_attributes]
-      Thread.current[:inheritable_attributes] = Thread.current[:inheritable_attributes].merge(:rf_logger_request_tags => tagged)
+      (Thread.current[:inheritable_attributes] ||= {})[:rf_logger_request_tags] = tagged
     end
 
     def request_object

--- a/lib/rf_logger/request_middleware.rb
+++ b/lib/rf_logger/request_middleware.rb
@@ -1,0 +1,24 @@
+module RfLogger
+  class RequestMiddleware
+    def initialize(app, custom_env_key: nil)
+      @app            = app
+      @custom_env_key = custom_env_key
+    end
+
+    def call(env)
+      @env = env
+      Thread.current[:rf_logger_request_id] = custom_env_key || request_id
+      @app.call(@env)
+    end
+
+    private
+
+    def custom_env_key
+      @env[@custom_env_key] if @custom_env_key
+    end
+
+    def request_id
+      @env.uuid if @env.respond_to? :uuid
+    end
+  end
+end

--- a/lib/rf_logger/request_tags.rb
+++ b/lib/rf_logger/request_tags.rb
@@ -1,8 +1,7 @@
 module RfLogger
   module RequestTags
     def rf_logger_request_tags
-      Thread.current[:inheritable_attributes] = {} if Thread.current[:inheritable_attributes].nil?
-      Thread.current[:inheritable_attributes][:rf_logger_request_tags] || {}
+      (Thread.current[:inheritable_attributes] ||= {})[:rf_logger_request_tags] ||= {}
     end
   end
 end

--- a/lib/rf_logger/request_tags.rb
+++ b/lib/rf_logger/request_tags.rb
@@ -1,0 +1,8 @@
+module RfLogger
+  module RequestTags
+    def rf_logger_request_tags
+      Thread.current[:inheritable_attributes] = {} if Thread.current[:inheritable_attributes].nil?
+      Thread.current[:inheritable_attributes][:rf_logger_request_tags] || {}
+    end
+  end
+end

--- a/lib/rf_logger/sequel_logger.rb
+++ b/lib/rf_logger/sequel_logger.rb
@@ -1,6 +1,10 @@
 require 'json'
+require "rf_logger/request_id"
+
 module RfLogger
   class SequelLogger < Sequel::Model(Sequel::Model.db.fetch('select 1'))
+    extend RequestId
+
     class << self
       def inherited(subclass)
         super
@@ -18,6 +22,7 @@ module RfLogger
       end
 
       def add(level, entry)
+        entry[:request_id] = request_id
         entry[:level] = RfLogger::LEVELS.index(level.to_sym)
         entry[:actor] = entry[:actor] || ''
         entry[:metadata] = entry[:metadata] || {}

--- a/lib/rf_logger/sequel_logger.rb
+++ b/lib/rf_logger/sequel_logger.rb
@@ -1,9 +1,9 @@
 require 'json'
-require "rf_logger/request_id"
+require "rf_logger/request_tags"
 
 module RfLogger
   class SequelLogger < Sequel::Model(Sequel::Model.db.fetch('select 1'))
-    extend RequestId
+    extend RequestTags
 
     class << self
       def inherited(subclass)
@@ -22,7 +22,7 @@ module RfLogger
       end
 
       def add(level, entry)
-        entry[:request_id] = request_id
+        entry[:rf_logger_request_tags] = rf_logger_request_tags
         entry[:level] = RfLogger::LEVELS.index(level.to_sym)
         entry[:actor] = entry[:actor] || ''
         entry[:metadata] = entry[:metadata] || {}

--- a/lib/rf_logger/version.rb
+++ b/lib/rf_logger/version.rb
@@ -1,3 +1,3 @@
 module RfLogger
-  VERSION = "0.0.6"
+  VERSION = "1.0.0"
 end

--- a/spec/lib/rf_logger/rails_logger_spec.rb
+++ b/spec/lib/rf_logger/rails_logger_spec.rb
@@ -1,7 +1,8 @@
-require File.expand_path( File.dirname( __FILE__ ) + '/../../../lib/rf_logger/rails_logger' )
-require 'active_record'
+require "rf_logger/rails_logger"
+require "active_record"
 
 describe RfLogger::RailsLogger do
+  include_examples "RfLogger::RequestId", subject: described_class
 
   before do
     allow(described_class).to receive(:create)
@@ -13,6 +14,7 @@ describe RfLogger::RailsLogger do
       it "creates new Log object with level = #{level}" do
         described_class.send(level.to_sym, action: 'log me')
         expect(described_class).to have_received(:create).with(
+          :request_id => "uninitialized",
           :level => RfLogger::LEVELS.index(level.to_sym),
           :action => 'log me',
           :actor => nil,

--- a/spec/lib/rf_logger/rails_logger_spec.rb
+++ b/spec/lib/rf_logger/rails_logger_spec.rb
@@ -3,18 +3,18 @@ require "active_record"
 
 describe RfLogger::RailsLogger do
   include_examples "RfLogger::RequestId", subject: described_class
-
-  before do
-    allow(described_class).to receive(:create)
-    allow(described_class).to receive(:table_name)
-  end
-
   RfLogger::LEVELS.each do |level|
+    before do
+      allow(described_class).to receive(:create)
+      allow(described_class).to receive(:table_name)
+      allow(described_class).to receive(:rf_logger_request_tags){{}}
+    end
+
     describe ".#{level}" do
       it "creates new Log object with level = #{level}" do
         described_class.send(level.to_sym, action: 'log me')
         expect(described_class).to have_received(:create).with(
-          :request_id => "uninitialized",
+          :rf_logger_request_tags => {},
           :level => RfLogger::LEVELS.index(level.to_sym),
           :action => 'log me',
           :actor => nil,

--- a/spec/lib/rf_logger/request_middleware_spec.rb
+++ b/spec/lib/rf_logger/request_middleware_spec.rb
@@ -1,24 +1,74 @@
 require "rf_logger/request_middleware"
 
 RSpec.describe RfLogger::RequestMiddleware do
-  subject { RfLogger::RequestMiddleware.new(*init_arguments).call(env) }
+  subject { RfLogger::RequestMiddleware.new(*init_arguments).call({}) }
   let(:init_arguments) { [->(_) {}] }
-  before { subject }
   after { Thread.current[:rf_logger_request_id] = nil }
 
-  context "when env responds to uuid" do
-    let(:env) { double(uuid: "uuid-from_env") }
-    it "sets current Thread variable" do
-      expect(Thread.current[:rf_logger_request_id]).to eq "uuid-from_env"
+  context "Rails" do
+    before { stub_const("ActionDispatch::Request", double("ActionDispatch::Request", new: double("ActionDispatch::Request#", uuid: "uuid-from_env"))) }
+    context "when env responds to uuid" do
+      it "sets current Thread variable" do
+        subject
+        expect(Thread.current[:inheritable_attributes][:rf_logger_request_tags]).to eq({ :request_id => "uuid-from_env" })
+      end
+    end
+
+    context "from custom_env_key" do
+      let(:init_arguments) { [->(_) {}, tagged: { custom_env_key: "other_request_id" }] }
+      before { stub_const("ActionDispatch::Request", double("ActionDispatch::Request", new: double("ActionDispatch::Request#", other_request_id: "other_request_id"))) }
+
+      it "sets current Thread variable" do
+        subject
+        expect(Thread.current[:inheritable_attributes][:rf_logger_request_tags]).to eq({ :custom_env_key => "other_request_id" })
+      end
     end
   end
 
-  context "from custom_env_key" do
-    let(:init_arguments) { [->(_) {}, { custom_env_key: "other_request_id" }] }
-    let(:env) { { "other_request_id" => "uuid-from_other" } }
+  context "Rory" do
+    before { stub_const("Rory::Request", double("Rory::Request", new: double("Rory::Request#", uuid: "uuid-from_env"))) }
+    context "when env responds to uuid" do
+      it "sets current Thread variable" do
+        subject
+        expect(Thread.current[:inheritable_attributes][:rf_logger_request_tags]).to eq({ :request_id => "uuid-from_env" })
+      end
+    end
 
-    it "sets current Thread variable" do
-      expect(Thread.current[:rf_logger_request_id]).to eq "uuid-from_other"
+    context "from custom_env_key" do
+      let(:init_arguments) { [->(_) {}, tagged: { custom_env_key: "other_request_id" }] }
+      before { stub_const("ActionDispatch::Request", double("ActionDispatch::Request", new: double("ActionDispatch::Request#", other_request_id: "other_request_id"))) }
+
+      it "sets current Thread variable" do
+        subject
+        expect(Thread.current[:inheritable_attributes][:rf_logger_request_tags]).to eq({ :custom_env_key => "other_request_id" })
+      end
+    end
+  end
+
+  context "Other Framework Context" do
+    context "when env responds to uuid" do
+      let(:init_arguments) { [->(_) {}, rack_request_class: double("rack_request_class", new: double("rack_request_class#", uuid: "uuid-from_env"))] }
+      it "sets current Thread variable" do
+        subject
+        expect(Thread.current[:inheritable_attributes][:rf_logger_request_tags]).to eq({ :request_id => "uuid-from_env" })
+      end
+    end
+
+    context "from custom_env_key" do
+      let(:init_arguments) { [->(_) {}, tagged: { custom_env_key: "other_request_id" }, rack_request_class: double("rack_request_class", new: double("rack_request_class#", other_request_id: "other_request_id"))] }
+
+      it "sets current Thread variable" do
+        subject
+        expect(Thread.current[:inheritable_attributes][:rf_logger_request_tags]).to eq({ :custom_env_key => "other_request_id" })
+      end
+    end
+
+    context "when rack_request_class is not given" do
+      let(:init_arguments) { [->(_) {}] }
+
+      it "sets current Thread variable" do
+        expect { subject }.to raise_error(ArgumentError)
+      end
     end
   end
 end

--- a/spec/lib/rf_logger/request_middleware_spec.rb
+++ b/spec/lib/rf_logger/request_middleware_spec.rb
@@ -1,74 +1,35 @@
 require "rf_logger/request_middleware"
 
 RSpec.describe RfLogger::RequestMiddleware do
-  subject { RfLogger::RequestMiddleware.new(*init_arguments).call({}) }
+  subject { RfLogger::RequestMiddleware.new(*init_arguments).call(env) }
+  let(:env) { {} }
   let(:init_arguments) { [->(_) {}] }
   after { Thread.current[:rf_logger_request_id] = nil }
 
-  context "Rails" do
-    before { stub_const("ActionDispatch::Request", double("ActionDispatch::Request", new: double("ActionDispatch::Request#", uuid: "uuid-from_env"))) }
-    context "when env responds to uuid" do
-      it "sets current Thread variable" do
-        subject
-        expect(Thread.current[:inheritable_attributes][:rf_logger_request_tags]).to eq({ :request_id => "uuid-from_env" })
-      end
-    end
-
-    context "from custom_env_key" do
-      let(:init_arguments) { [->(_) {}, tagged: { custom_env_key: "other_request_id" }] }
-      before { stub_const("ActionDispatch::Request", double("ActionDispatch::Request", new: double("ActionDispatch::Request#", other_request_id: "other_request_id"))) }
-
-      it "sets current Thread variable" do
-        subject
-        expect(Thread.current[:inheritable_attributes][:rf_logger_request_tags]).to eq({ :custom_env_key => "other_request_id" })
-      end
+  context "when tagged is missing" do
+    let(:env) { { "X-Request-Id" => "uuid-from_env" } }
+    it "defaults to getting the request_id" do
+      subject
+      expect(Thread.current[:inheritable_attributes][:rf_logger_request_tags]).to eq({ :request_id => "uuid-from_env" })
     end
   end
 
-  context "Rory" do
-    before { stub_const("Rory::Request", double("Rory::Request", new: double("Rory::Request#", uuid: "uuid-from_env"))) }
-    context "when env responds to uuid" do
-      it "sets current Thread variable" do
-        subject
-        expect(Thread.current[:inheritable_attributes][:rf_logger_request_tags]).to eq({ :request_id => "uuid-from_env" })
-      end
-    end
+  context "when tagged option is given that exists" do
+    let(:env) { { "X-OtherHeader" => "other_request_id" } }
+    let(:init_arguments) { [->(_) {}, tagged: { custom_env_key: "X-OtherHeader" }] }
 
-    context "from custom_env_key" do
-      let(:init_arguments) { [->(_) {}, tagged: { custom_env_key: "other_request_id" }] }
-      before { stub_const("ActionDispatch::Request", double("ActionDispatch::Request", new: double("ActionDispatch::Request#", other_request_id: "other_request_id"))) }
-
-      it "sets current Thread variable" do
-        subject
-        expect(Thread.current[:inheritable_attributes][:rf_logger_request_tags]).to eq({ :custom_env_key => "other_request_id" })
-      end
+    it "sets current Thread variable" do
+      subject
+      expect(Thread.current[:inheritable_attributes][:rf_logger_request_tags]).to eq({ :custom_env_key => "other_request_id" })
     end
   end
 
-  context "Other Framework Context" do
-    context "when env responds to uuid" do
-      let(:init_arguments) { [->(_) {}, rack_request_class: double("rack_request_class", new: double("rack_request_class#", uuid: "uuid-from_env"))] }
-      it "sets current Thread variable" do
-        subject
-        expect(Thread.current[:inheritable_attributes][:rf_logger_request_tags]).to eq({ :request_id => "uuid-from_env" })
-      end
-    end
+  context "when tagged option is given that does not exists" do
+    let(:init_arguments) { [->(_) {}, tagged: { custom_env_key: "X-WontFindMe" }] }
 
-    context "from custom_env_key" do
-      let(:init_arguments) { [->(_) {}, tagged: { custom_env_key: "other_request_id" }, rack_request_class: double("rack_request_class", new: double("rack_request_class#", other_request_id: "other_request_id"))] }
-
-      it "sets current Thread variable" do
-        subject
-        expect(Thread.current[:inheritable_attributes][:rf_logger_request_tags]).to eq({ :custom_env_key => "other_request_id" })
-      end
-    end
-
-    context "when rack_request_class is not given" do
-      let(:init_arguments) { [->(_) {}] }
-
-      it "sets current Thread variable" do
-        expect { subject }.to raise_error(ArgumentError)
-      end
+    it "sets current Thread variable" do
+      subject
+      expect(Thread.current[:inheritable_attributes][:rf_logger_request_tags]).to eq({:custom_env_key=>nil})
     end
   end
 end

--- a/spec/lib/rf_logger/request_middleware_spec.rb
+++ b/spec/lib/rf_logger/request_middleware_spec.rb
@@ -1,0 +1,24 @@
+require "rf_logger/request_middleware"
+
+RSpec.describe RfLogger::RequestMiddleware do
+  subject { RfLogger::RequestMiddleware.new(*init_arguments).call(env) }
+  let(:init_arguments) { [->(_) {}] }
+  before { subject }
+  after { Thread.current[:rf_logger_request_id] = nil }
+
+  context "when env responds to uuid" do
+    let(:env) { double(uuid: "uuid-from_env") }
+    it "sets current Thread variable" do
+      expect(Thread.current[:rf_logger_request_id]).to eq "uuid-from_env"
+    end
+  end
+
+  context "from custom_env_key" do
+    let(:init_arguments) { [->(_) {}, { custom_env_key: "other_request_id" }] }
+    let(:env) { { "other_request_id" => "uuid-from_other" } }
+
+    it "sets current Thread variable" do
+      expect(Thread.current[:rf_logger_request_id]).to eq "uuid-from_other"
+    end
+  end
+end

--- a/spec/lib/rf_logger/sequel_logger_spec.rb
+++ b/spec/lib/rf_logger/sequel_logger_spec.rb
@@ -3,6 +3,8 @@ Sequel::Model.db = Sequel.mock
 require File.expand_path( File.dirname( __FILE__ ) + '/../../../lib/rf_logger/sequel_logger' )
 
 describe RfLogger::SequelLogger do
+  include_examples "RfLogger::RequestId", subject: described_class
+
   before :each do
     allow(Time).to receive_messages(:now => 'NOW')
     described_class.dataset =
@@ -29,6 +31,7 @@ describe RfLogger::SequelLogger do
   describe '.add' do
     it 'adds given object to the log at given level' do
       expect(RfLogger::SequelLogger).to receive(:create).with(
+        :request_id => "uninitialized",
         :actor => 'cat herder',
         :action => 'herd some cats',
         :target_type => 'Cat',
@@ -61,6 +64,7 @@ describe RfLogger::SequelLogger do
 
     it 'sets actor to blank string if not provided' do
       expect(described_class).to receive(:create).with(
+        :request_id => 'uninitialized',
         :actor => '',
         :action => 'palpitate',
         :metadata => {},
@@ -72,6 +76,7 @@ describe RfLogger::SequelLogger do
 
     it 'sets metadata to empty hash if not provided' do
       expect(described_class).to receive(:create).with(
+        :request_id => 'uninitialized',
         :actor => '',
         :action => 'palpitate',
         :metadata => {},

--- a/spec/lib/rf_logger/sequel_logger_spec.rb
+++ b/spec/lib/rf_logger/sequel_logger_spec.rb
@@ -10,6 +10,7 @@ describe RfLogger::SequelLogger do
     described_class.dataset =
       Sequel::Model.db[:logs].columns(:actor, :action, :target_type, :target_id,
                :metadata, :created_at, :updated_at, :level)
+    allow(described_class).to receive(:rf_logger_request_tags){{request_id: "909090"}}
   end
 
   RfLogger::LEVELS.each do |level|
@@ -31,7 +32,7 @@ describe RfLogger::SequelLogger do
   describe '.add' do
     it 'adds given object to the log at given level' do
       expect(RfLogger::SequelLogger).to receive(:create).with(
-        :request_id => "uninitialized",
+        :rf_logger_request_tags=>{:request_id=>"909090"},
         :actor => 'cat herder',
         :action => 'herd some cats',
         :target_type => 'Cat',
@@ -64,7 +65,7 @@ describe RfLogger::SequelLogger do
 
     it 'sets actor to blank string if not provided' do
       expect(described_class).to receive(:create).with(
-        :request_id => 'uninitialized',
+        :rf_logger_request_tags=>{:request_id=>"909090"},
         :actor => '',
         :action => 'palpitate',
         :metadata => {},
@@ -76,7 +77,7 @@ describe RfLogger::SequelLogger do
 
     it 'sets metadata to empty hash if not provided' do
       expect(described_class).to receive(:create).with(
-        :request_id => 'uninitialized',
+        :rf_logger_request_tags=>{:request_id=>"909090"},
         :actor => '',
         :action => 'palpitate',
         :metadata => {},

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 require 'simplecov'
 SimpleCov.start
+lib = File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
@@ -8,7 +10,6 @@ Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each {|f| require f}
 require './lib/rf_logger'
 
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.order = 'random'
 end

--- a/spec/support/request_id_shared_examples.rb
+++ b/spec/support/request_id_shared_examples.rb
@@ -1,0 +1,12 @@
+RSpec.shared_context "RfLogger::RequestId" do |subject:|
+  context "when Thread variable is set" do
+    before { Thread.current[:rf_logger_request_id] = "request-uuid-0000-1111" }
+    it { expect(subject.request_id).to eq "request-uuid-0000-1111" }
+    after { Thread.current[:rf_logger_request_id] = nil }
+  end
+
+  context "when Thread variable is not set" do
+    before { Thread.current[:rf_logger_request_id] = nil }
+    it { expect(subject.request_id).to eq "uninitialized" }
+  end
+end

--- a/spec/support/request_id_shared_examples.rb
+++ b/spec/support/request_id_shared_examples.rb
@@ -1,12 +1,21 @@
 RSpec.shared_context "RfLogger::RequestId" do |subject:|
-  context "when Thread variable is set" do
-    before { Thread.current[:rf_logger_request_id] = "request-uuid-0000-1111" }
-    it { expect(subject.request_id).to eq "request-uuid-0000-1111" }
-    after { Thread.current[:rf_logger_request_id] = nil }
-  end
+  describe "#rf_logger_request_tags" do
+  before {allow(subject).to receive(:rf_logger_request_tags).and_call_original}
+    context "When thread var inheritable_attributes is nil" do
+      before { Thread.current[:inheritable_attributes] = nil }
+      it { expect(subject.rf_logger_request_tags).to eq({}) }
+    end
 
-  context "when Thread variable is not set" do
-    before { Thread.current[:rf_logger_request_id] = nil }
-    it { expect(subject.request_id).to eq "uninitialized" }
+    context "when thread var inheritable_attributes is empty hash" do
+      before { Thread.current[:inheritable_attributes] = {} }
+      it { expect(subject.rf_logger_request_tags).to eq({}) }
+    end
+
+    context "when thread var inheritable_attributes has key rf_logger_request_tags" do
+      before { Thread.current[:inheritable_attributes] = { rf_logger_request_tags: { hello: "goodbye" } } }
+      it { expect(subject.rf_logger_request_tags).to eq({ hello: "goodbye" }) }
+    end
+
+    before { Thread.current[:inheritable_attributes] = nil }
   end
 end


### PR DESCRIPTION
This version has a breaking change that will require a db migration.
Table log will need to add the column request_id: String.
Incrementing to version 1.0.0
